### PR TITLE
Link color change

### DIFF
--- a/hugo-backend/static/css/storageos.css
+++ b/hugo-backend/static/css/storageos.css
@@ -2175,7 +2175,7 @@ p a {
 a,
 
 a:hover {
-  color: #081d60;
+  color: #3176d9;
 }
 
 img,


### PR DESCRIPTION
Following James request, the hrefs on the docs are too invisible, so this change is a proposal to make the links more visible. As a consequence the landing pages with the titles also have the title color changed. 
<img width="976" alt="Screenshot 2022-08-03 at 10 25 45" src="https://user-images.githubusercontent.com/1422556/182577487-876c71b3-92dd-4fe9-958c-7fbb27a59290.png">
<img width="951" alt="Screenshot 2022-08-03 at 10 25 52" src="https://user-images.githubusercontent.com/1422556/182577501-e4bc0e8e-6a15-45bb-8b62-f40d865475d7.png">

